### PR TITLE
refactor: separate into individual crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/*"]
+members = ["crates/*", "crates/car-thing-bin", "crates/car-thing-lib"]
 
 [workspace.lints.clippy]
 std_instead_of_core = "warn"

--- a/crates/car-thing-bin/Cargo.toml
+++ b/crates/car-thing-bin/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "car-thing"
+name = "car-thing-bin"
 version = "0.1.0"
 edition = "2021"
 description = "A tool to interact with Car Thing devices"
 
 [dependencies]
 clap = { version = "4.5.11", features = ["derive"] }
-rusb = "0.9.4"
+car-thing-lib = { path = "../car-thing-lib" }
 
 [lints]
 workspace = true

--- a/crates/car-thing-bin/src/main.rs
+++ b/crates/car-thing-bin/src/main.rs
@@ -1,0 +1,34 @@
+use clap::{Parser, Subcommand};
+use car_thing_lib::{CarThing, CarThings};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+	#[clap(subcommand)]
+	command: SubCommand,
+}
+
+#[derive(Subcommand)]
+enum SubCommand {
+	/// Find car thing devices and print the device mode
+	FindDevice,
+}
+
+fn main() -> Result<(), Box<dyn core::error::Error>> {
+	let args = Cli::parse();
+
+	match args.command {
+		SubCommand::FindDevice => {
+			let devices = rusb::devices()?;
+
+			for car_thing in CarThings(devices.iter()) {
+				println!(
+					"Found car thing booted in {:?} mode",
+					car_thing.mode()?
+				);
+			}
+		}
+	}
+
+	Ok(())
+}

--- a/crates/car-thing-lib/Cargo.toml
+++ b/crates/car-thing-lib/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "car-thing-lib"
+version = "0.1.0"
+edition = "2021"
+description = "A library to interact with Car Thing devices"
+
+[dependencies]
+rusb = "0.9.4"
+
+[lints]
+workspace = true

--- a/crates/car-thing-lib/src/lib.rs
+++ b/crates/car-thing-lib/src/lib.rs
@@ -1,37 +1,4 @@
-use clap::{Parser, Subcommand};
 use rusb::{Device, Devices, GlobalContext};
-
-#[derive(Parser)]
-#[command(version, about, long_about = None)]
-struct Cli {
-	#[clap(subcommand)]
-	command: SubCommand,
-}
-
-#[derive(Subcommand)]
-enum SubCommand {
-	/// Find car thing devices and print the device mode
-	FindDevice,
-}
-
-fn main() -> Result<(), Box<dyn core::error::Error>> {
-	let args = Cli::parse();
-
-	match args.command {
-		SubCommand::FindDevice => {
-			let devices = rusb::devices()?;
-
-			for car_thing in CarThings(devices.iter()) {
-				println!(
-					"Found car thing booted in {:?} mode",
-					car_thing.mode()?
-				);
-			}
-		}
-	}
-
-	Ok(())
-}
 
 const DEV_ID_VENDOR: u16 = 0x1B8E;
 const DEV_ID_PRODUCT: u16 = 0xC003;


### PR DESCRIPTION
Fixes #7

Separate the `car-thing` binary and library into individual crates.

* Modify `Cargo.toml` to add `car-thing-bin` and `car-thing-lib` to the `members` array.
* Rename `crates/car-thing/Cargo.toml` to `crates/car-thing-bin/Cargo.toml` and update the package name to `car-thing-bin`. Add dependency for `car-thing-lib`.
* Rename `crates/car-thing/src/main.rs` to `crates/car-thing-lib/src/lib.rs` and remove the binary implementation.
* Add `crates/car-thing-bin/src/main.rs` to implement the `car-thing-bin` binary using `clap` and `car-thing-lib`.
* Add `crates/car-thing-lib/Cargo.toml` to define the `car-thing-lib` package and add dependency for `rusb`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tinted-software/car-thing-tools/issues/7?shareId=785b8cd3-2020-448f-ad2c-66c702613864).